### PR TITLE
Fixes crash when URL points to a domain without PTR record

### DIFF
--- a/os-scan/get_AppDefinitions.py
+++ b/os-scan/get_AppDefinitions.py
@@ -37,7 +37,7 @@ def get_app_definitions(environment,app_module_name,header):
         print(f"| {Fore.WHITE}Environment: {Style.DIM}[NAME={environment_name} KEY={environment_key}]{Style.RESET_ALL}")
         print(f"| {Fore.WHITE}User tenant provider: {Style.DIM}{user_provider}{Style.RESET_ALL}")
         print(f"| {Fore.WHITE}Home module key: {Style.DIM}{home_module_key}{Style.RESET_ALL}")
-        print(f"| {Fore.WHITE}Real DNS (enterprise only): {Style.DIM}{get_RealAddress.get_address(environment)}/{app_module_name}{Style.RESET_ALL}")
+        print(f"| {Fore.WHITE}Real DNS (enterprise only): {Style.DIM}{get_RealAddress.get_address(environment)}{Style.RESET_ALL}")
 
         # Return
         return application_name

--- a/os-scan/get_RealAddress.py
+++ b/os-scan/get_RealAddress.py
@@ -1,10 +1,14 @@
 import socket
 
 def get_address(url):
-  url = url.replace("https://","")
-  try:
-    host = socket.gethostbyname(url)
-    ip_address = socket.gethostbyaddr(host)[0]
-    return ip_address
-  except socket.gaierror:
-    return url
+    url = url.replace("https://", "").replace("http://", "")
+    try:
+        host = socket.gethostbyname(url)
+        try:
+            ip_address = socket.gethostbyaddr(host)[0]  # Try to get the PTR record (reverse DNS)
+            return ip_address
+        except socket.herror:  # If no PTR record is found
+            return "Not found!"
+    except socket.gaierror:  # If the domain can't be resolved, return the URL
+        return url
+


### PR DESCRIPTION
Hi, I noticed that if the URL provided points to a domain without a PTR record, the `gethostbyaddr()` function will fail because a reverse DNS lookup can't be performed, ultimately causing the script to crash since exceptions are not handled gracefully.

```sh
phsi@wsl:~/tools/OutSystems-Scan/os-scan (*)
> py osscan.py -u https://example.com
[...]
Traceback (most recent call last):
  File "/home/phsi/tools/OutSystems-Scan/os-scan/osscan.py", line 124, in <module>
    exploit_modules(data,environment,app_module_name)
  File "/home/phsi/tools/OutSystems-Scan/os-scan/osscan.py", line 80, in exploit_modules
    get_AppDefinitions.get_app_definitions(environment,app_module_name,header)
  File "/home/phsi/tools/OutSystems-Scan/os-scan/get_AppDefinitions.py", line 40, in get_app_definitions
    print(f"| {Fore.WHITE}Real DNS (enterprise only): {Style.DIM}{get_RealAddress.get_address(environment)}/{app_module_name}{Style.RESET_ALL}")
                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/phsi/tools/OutSystems-Scan/os-scan/get_RealAddress.py", line 7, in get_address
    ip_address = socket.gethostbyaddr(host)[0]
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
socket.herror: [Errno 1] Unknown host
```

I added basic error handling in `get_RealAddress.py` to return "Not found!" if no PTR record exists and updated `get_AppDefinitions.py` slightly for cleaner output.